### PR TITLE
 bug: fixes incorrect link for big-omega

### DIFF
--- a/src/DB/product.json
+++ b/src/DB/product.json
@@ -1131,7 +1131,7 @@
     "productName": "Big Ω",
     "category": "extensions",
     "image": "https://shutr.bz/3Kz9GiB",
-    "link": "https://bit.ly/435pBfH",
+    "link": "https://bit.ly/47h6ocq",
     "description": "Enhance Leetcode experience with company tags like premium version"
   },
   {


### PR DESCRIPTION
Fixes incorrect link in Devlabs one-vercel-app:  https://devlabs-one.vercel.app/

- This PR is the submission to the issue #135 