### PR TITLE
bug: Saop2Day page is not loading on the devlabs one -vercel -app

### DIFF
--- a/src/DB/product.json
+++ b/src/DB/product.json
@@ -1068,7 +1068,7 @@
     "productName": "Soap2Day",
     "category": "movies",
     "image": "https://bit.ly/429nzdU",
-    "link": "https://ww.soap2dayfree.net/home/",
+    "link": "https://bit.ly/3QoM6XB",
     "description": "Stream movies freely"
   },
   {


### PR DESCRIPTION
This PR fixes a bug issue due to an incorrect link.

- This is the submission to issue #134 