### PR TITLE
Proper Padding to buttons

### DIFF
--- a/frontend/src/style/About.css
+++ b/frontend/src/style/About.css
@@ -91,7 +91,7 @@
 .repo-btn {
     font-weight: 500;
     margin: 0.8vmax 0 .8vmax 0;
-    padding: 8px 2px;
+    padding: 8px 22px;
     color: #000000;
     border-radius: 12px;
     background-color: #8b5cf6;
@@ -120,7 +120,7 @@
 .content-box {
     border: 1px solid  #8b5cf6;
     margin: 20px;
-    padding: 7px 12px;
+    padding: 12px 12px;
     border-radius: 12px;
     max-width: 20vw;
     transition: 0.5s;

--- a/frontend/src/style/Pagination.css
+++ b/frontend/src/style/Pagination.css
@@ -4,6 +4,10 @@ nav {
   padding: 0 10px;
 }
 
+.active>.page-link{
+  z-index: 0;
+}
+
 .pagination {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
## Related Issue
Issue Number #374 

## Description
In the about us section there are buttons like star the repo and learn more in which there should be more padding to look good. I fixed that problem. Also, I sorted the pagination bug in which active page goes above the nav bar.

## Type of PR

- [x] Bug fix

## Screenshots / videos (if applicable)
Before
![image](https://github.com/HimanshuNarware/Devlabs/assets/95460188/f84fa687-3d13-43f1-83e5-7985c87c921a)
![image](https://github.com/HimanshuNarware/Devlabs/assets/95460188/382cf8da-873c-4d8f-9dac-62736f5fcac5)

After
![image](https://github.com/HimanshuNarware/Devlabs/assets/95460188/9b3001f9-6924-4525-8898-16586353ddaf)
![image](https://github.com/HimanshuNarware/Devlabs/assets/95460188/52b46e64-3c71-44f7-8c9b-8ab5f2b8c9c2)

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
[Include any additional information or context that might be helpful for reviewers.]
