### PR TITLE
Improved contrast of text in both themes

### DIFF
--- a/frontend/src/style/NotFound.css
+++ b/frontend/src/style/NotFound.css
@@ -18,12 +18,10 @@
   .not-found-heading {
     font-size: 36px;
     font-weight: bold;
-    color: #333;
   }
   
   .not-found-text {
     font-size: 18px;
-    color: #777;
   }
   
   .not-found-image {


### PR DESCRIPTION
## Related Issue
Closes #546 By improving the contrast ratio of text in the Error 404 page

## Description
The fixed contrast ratio works in both the themes.

## Type of PR

- [x] Bug fix
- [x] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
![image](https://github.com/HimanshuNarware/Devlabs/assets/96773379/8d4cb848-2692-4d86-a2c7-12b031031e3b)
![image](https://github.com/HimanshuNarware/Devlabs/assets/96773379/a546096b-5d43-4203-9277-3aec5df22dd4)

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
