### PR TITLE
fixed empty search message

### DIFF
--- a/frontend/src/Component/Navbar/NavbarRight.js
+++ b/frontend/src/Component/Navbar/NavbarRight.js
@@ -22,7 +22,9 @@ function NavbarRight(props) {
 
   const handleSearch = (e) => {
     e.preventDefault();
-    props.setSearchQuery(searchQuery); // Pass the search query to the parent component (App)
+    
+    if(searchQuery.trim() != '')
+      props.setSearchQuery(searchQuery.trim()); // Pass the search query to the parent component (App)
   };
 
   const clearSearchHandler = (e) => {


### PR DESCRIPTION
## Related Issue
Issue: #568

## Description
1. I am using `.trim()` function to trim search query, After trimming, if search query is not empty, then only I'll update `props.searchQuery`.
2. In `props.setSearchQuery()`, I am also passing searchQuery after trimming, because we don't need extra spaces in starting and ending.


## Type of PR

- [x] Bug fix
- [x] Feature enhancement

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.

