### PR TITLE
Fixed images not visible in some browsers

### DIFF
--- a/frontend/src/DB/product.json
+++ b/frontend/src/DB/product.json
@@ -87,7 +87,7 @@
 	{
 		"productName": "w3schools",
 		"category": "coding",
-		"image": "https://th.bing.com/th/id/OIP.P0MUDJ0LTZTB6MSW_mw-pwAAAA?rs=1&pid=ImgDetMain",
+		"image": "https://upload.wikimedia.org/wikipedia/commons/a/a0/W3Schools_logo.svg",
 		"link": "https://w3schools.com/",
 		"description": "Tutorials on web development, programming languages, and other related technologies"
 	},
@@ -101,7 +101,7 @@
 	{
 		"productName": "Javatpoint",
 		"category": "coding",
-		"image": "https://th.bing.com/th?id=ODLS.f204db9f-22d4-476b-8f50-c9015f0e7ece&w=32&h=32&qlt=90&pcl=fffffa&o=6&pid=1.2",
+		"image": "https://cdn.freelogovectors.net/wp-content/uploads/2022/06/javapoint-logo-freelogovectors.net_.png",
 		"link": "https://www.javatpoint.com/",
 		"description": "Study materials such as tutorials, articles, and resources for Java programming and other related technologies"
 	},
@@ -164,7 +164,7 @@
 	{
 		"productName": "ChatGPT Writer",
 		"category": "tools",
-		"image": "https://th.bing.com/th?id=ODLS.55a479aa-1767-419c-80d5-972f3f0928f2&w=32&h=32&qlt=90&pcl=fffffa&o=6&pid=1.2",
+		"image": "https://store-images.s-microsoft.com/image/apps.41733.286a6164-6562-4a8e-a779-a449ad869ff8.5450d70f-7fdf-4ee6-8f65-e47c77aff6f3.f601c8ff-e835-4f1c-b202-88235a8fd6ca",
 		"link": "https://chatgptwriter.ai/",
 		"description": "Write emails & messages, fix grammar mistakes, rephrase text, change writing tone, summarize text."
 	},
@@ -262,14 +262,14 @@
 	{
 		"productName": "Himalayas",
 		"category": "remote",
-		"image": "https://th.bing.com/th?id=ODLS.bf0d843a-168b-4836-8cbc-986c1fb41bb9&w=32&h=32&qlt=90&pcl=fffffa&o=6&pid=1.2",
+		"image": "https://uploads-ssl.webflow.com/61db6de47b013600851b957b/61e0ec7d79fc0a4286bcf9ad_himalayas.jpg",
 		"link": "https://himalayas.app/",
 		"description": "Himalayas is a job board for remote workers."
 	},
 	{
 		"productName": "KhanAcademy",
 		"category": "remote",
-		"image": "https://th.bing.com/th/id/OIP.krs23uVyEDRATLFhfuIjsAHaHa?pid=ImgDet&rs=1",
+		"image": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQkD27JRbnRUkTmfVQP6OOupXZKjfOhF5JMLA&s",
 		"link": "https://www.khanacademy.org/",
 		"description": "Khan Academy is an American non-profit educational organization created in 2006 by Sal Khan."
 	},
@@ -430,7 +430,7 @@
 	{
 		"productName": "Figma.com",
 		"category": "tools",
-		"image": "https://th.bing.com/th?id=OSK.45962e2c46c7cbc263880160290e9005&w=46&h=46&c=11&rs=1&qlt=80&o=6&dpr=1.6&pid=SANGAM",
+		"image": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/33/Figma-logo.svg/1667px-Figma-logo.svg.png",
 		"link": "https://www.figma.com/",
 		"description": " Online design and prototyping tool."
 	},
@@ -746,7 +746,7 @@
 	{
 		"productName": "flaticon",
 		"category": "web",
-		"image": "https://th.bing.com/th/id/OIP.MHkSy2nH23lZjX3d47rBIwHaD4?w=319&h=180&c=7&r=0&o=5&dpr=1.3&pid=1.7",
+		"image": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQzZcZkHb1ryoSbKABkVp_5kVVOdb7dmN6R_Q&s",
 		"link": "https://www.flaticon.com/",
 		"description": "Collection of free vector icons for web design and graphic design."
 	},
@@ -1404,7 +1404,7 @@
 	{
 		"productName": "Fontshare",
 		"category": "tools",
-		"image": "https://th.bing.com/th?id=ODLS.f90e65d2-1373-4759-8e85-f8e401a732a1&w=32&h=32&qlt=90&pcl=fffffa&o=6&pid=1.2",
+		"image": "https://pbs.twimg.com/profile_images/1373587812109361154/LmzaPuq-_400x400.jpg",
 		"link": "https://www.fontshare.com/",
 		"description": "A growing collection of professional grade fonts that are 100% free for personal and commercial use."
 	},
@@ -1474,7 +1474,7 @@
 	{
 		"productName": "PDF24",
 		"category": "tools",
-		"image": "https://th.bing.com/th/id/OIP.6-l4-EpiTmvnk5h4ug5BQwAAAA?w=173&h=180&c=7&r=0&o=5&dpr=1.6&pid=1.7",
+		"image": "https://upload.wikimedia.org/wikipedia/commons/c/c0/PDF24_Creator_application_logo_256x256.png",
 		"link": "https://bit.ly/45sK1jN",
 		"description": "One stop solution for all your pdf problems."
 	},
@@ -2015,7 +2015,7 @@
 	{
 		"productName": "DESIGNS.AI",
 		"category": "resume",
-		"image": "https://th.bing.com/th?id=ODLS.b9345792-58b3-41d1-ac97-e729bf23e6a7&w=32&h=32&qlt=90&pcl=fffffa&o=6&pid=1.2",
+		"image": "https://media.licdn.com/dms/image/C510BAQGUMZ9orIbsXw/company-logo_200_200/0/1630573724151/designs_ai_logo?e=2147483647&v=beta&t=nbkyEmINIZXx1URuwI_sXK7z8L_VFzWS3nYBWkiU9iM",
 		"link": "https://designs.ai/design-types/resumes",
 		"description": "Build Professional resumes effortlessly with Designs.AI"
 	},
@@ -2253,7 +2253,7 @@
 	{
 		"productName": "Walkccc",
 		"category": "tools",
-		"image": "https://th.bing.com/th?id=ODLS.7f04f6a2-4ac9-4a36-8c72-20c0dbfc541f&w=32&h=32&qlt=90&pcl=fffffa&o=6&pid=1.2",
+		"image": "https://avatars.githubusercontent.com/u/14782909?v=4",
 		"link": "https://walkccc.me/LeetCode/",
 		"description": "Leetcode Solutions website"
 	},
@@ -2512,7 +2512,7 @@
 	{
 		"productName": "DEVPOST",
 		"category": "Coding",
-		"image": "https://th.bing.com/th/id/OIP.mKZIeb6ntJdq80RnqFP5JwAAAA?w=200&h=200&rs=1&pid=ImgDetMain",
+		"image": "https://pbs.twimg.com/profile_images/625987202909085696/KKYbLP8y_400x400.jpg",
 		"link": "https://devpost.com/",
 		"description": "The home for hackathons"
 	},
@@ -2596,7 +2596,7 @@
 	{
 		"productName": "Gitter",
 		"category": "tools",
-		"image": "https://th.bing.com/th?id=OSK.0ebf390893faa32c49097c747932708b&w=46&h=46&c=11&rs=1&qlt=80&o=6&dpr=1.6&pid=SANGAM",
+		"image": "https://cdn.icon-icons.com/icons2/2389/PNG/512/gitter_logo_icon_145248.png",
 		"link": "https://gitter.im/",
 		"description": "Chat and networking platform that helps to manage, grow and connect communities through messaging, content and discovery"
 	},
@@ -2687,7 +2687,7 @@
 	{
 		"productName": "PortSwigger",
 		"category": "ethical",
-		"image": "https://th.bing.com/th/id/OIP.lLWnEhhAbGIE0mVN8wm-fAAAAA?w=168&h=169&c=7&r=0&o=5&dpr=1.6&pid=1.7",
+		"image": "https://pbs.twimg.com/profile_images/1271377767091843073/ZIBb6Ur6_400x400.png",
 		"link": "https://portswigger.net/web-security",
 		"description": "The Web Security Academy is a free online training center for web application security."
 	},
@@ -2830,7 +2830,7 @@
 	{
 		"productName": "CyberChef",
 		"category": "ethical",
-		"image": "https://th.bing.com/th/id/OIP.KyzPtjDERPwHh2gXV8U2SwHaHa?rs=1&pid=ImgDetMain",
+		"image": "https://www.networkdefense.co/media/images/AND_CyberChef_trans.original.png",
 		"link": "https://cyberchef.org/",
 		"description": "CyberChef is a simple, intuitive and powerful tool for exploring data formats, encryption and compression."
 	},
@@ -2851,7 +2851,7 @@
 	{
 		"productName": "PentesterLab",
 		"category": "ethical",
-		"image": "https://th.bing.com/th/id/OIP.Xzp0HEEbnkjHrWJehpksPgHaHy?rs=1&pid=ImgDetMain",
+		"image": "https://www.pentesterlab.com/logo-icon.png",
 		"link": "https://www.pentesterlab.com/",
 		"description": "It is a fantastic platform to develop strong fonudation of web app security."
 	},


### PR DESCRIPTION
## Related Issue
Fixed #569 

## Description
I have fixed the logos of tools that were not loading in some browsers. The tools images fixed include:
1. w3schools
2. Javatpoint
3. ChatGPT Writer
4. Himalayas
5. KhanAcademy : The given logo was the wrong khan academy so I changed that too
6. Figma.com
7. flaticon
8. Fontshare
9. PDF24
10. Designs.ai
11. Walkccc
12. DEVPOST
13. Gitter
14. PortSwigger
15. CyberChef
16. PentesterLab

## Type of PR
- [x] Bug fix

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.

## Additional context:
The reason why it did not work in some browser might be because all the above tools links are a link of the format "th.bing.com/" and it fails to get called on page load because that type of link is blocked by some browsers and extension. So this issue is fixed by changing it with different links.
