### PR TITLE
Fixed Pagination Behaviour and its inteference in categories

### DIFF
--- a/frontend/src/Component/Home.js
+++ b/frontend/src/Component/Home.js
@@ -332,7 +332,7 @@ function Home(props) {
         </div>
         <div className="pagination">
           <ul>
-            <li className={`${currentPage === 1 ? "disable" : ""}`} title="No Previous Page">
+            <li className={`${currentPage === 1 ? "disable" : ""}`} title={`${currentPage === 1 ? "No Previous Page": ''}`}>
               <a href="#!" onClick={prePage}>
                 &lt;
               </a>
@@ -344,7 +344,7 @@ function Home(props) {
                 </a>
               </li>
             ))}
-            <li className={`${currentPage === npage ? "disable" : ""}`} title="No Next Page">
+            <li className={`${currentPage === npage ? "disable" : ""}`} title={`${currentPage === npage ? "No Next Page" : ''}`}>
               <a href="#!" onClick={nextPage} >
                 &gt;
               </a>

--- a/frontend/src/Component/Home.js
+++ b/frontend/src/Component/Home.js
@@ -25,7 +25,7 @@ function Home(props) {
   }
 
   const [currentPage, setCurrentPage] = useState(1);
-  const postPerpage = 16;
+  const postPerpage = 15;
   const lastPostIndex = currentPage * postPerpage;
   const firstPostIndex = lastPostIndex - postPerpage;
   const [dataBaseData, setDataBaseData] = useState([]);
@@ -47,9 +47,11 @@ function Home(props) {
   }, []);
 
   useEffect(() => {
+    // setCurrentPage(1);
     setLoading(true);
     const handleStorageChange = () => {
       setLocalStorageValue(localStorage.getItem("filter"));
+      setCurrentPage(1);
     };
     window.addEventListener("storage", handleStorageChange);
 
@@ -79,6 +81,7 @@ function Home(props) {
 
     return () => {
       window.removeEventListener("storage", handleStorageChange);
+      console.log('unmounting home...')
     };
   }, []);
 
@@ -107,12 +110,46 @@ function Home(props) {
     : allvalue;
 
   const currentPost =
-    filteredData.length > 16
+    filteredData.length > postPerpage
       ? filteredData.slice(firstPostIndex, lastPostIndex)
       : filteredData;
   const npage = Math.ceil(filteredData.length / postPerpage);
-  const numbers = [...Array(npage + 1).keys()].slice(1);
+  const numbers = updatePaginationNumber(currentPage, npage);
   const dispatch = useDispatch();
+
+  function updatePaginationNumber(currentPage, totalPage){
+    if(totalPage < 5)
+      return generateArrayOfNaturalNumber(1,totalPage);
+
+    const paginationListWith5Number = Math.floor(totalPage / 5);
+    const paginationMaxValue = 5 * paginationListWith5Number;
+
+    let startingPage = 0;
+
+    if(currentPage > paginationMaxValue){
+        const remainingPage = totalPage - paginationMaxValue;
+        startingPage = paginationMaxValue - (5 - remainingPage) + 1;
+    }else{
+      for(let ind = 1; ind <= paginationListWith5Number; ind++){
+        if(currentPage <= 5*ind){
+          startingPage = 5*(ind-1) + 1;
+          break;
+        }
+      }
+    }
+
+    return generateArrayOfNaturalNumber(startingPage);
+  }
+
+  function generateArrayOfNaturalNumber(pageNo, pageCount = 5){
+    const result = [];
+
+    while(pageCount --){
+      result.push(pageNo++);
+    }
+
+    return result;
+  }
 
   function prePage() {
     if (currentPage > 1) {
@@ -295,7 +332,7 @@ function Home(props) {
         </div>
         <div className="pagination">
           <ul>
-            <li>
+            <li className={`${currentPage === 1 ? "disable" : ""}`} title="No Previous Page">
               <a href="#!" onClick={prePage}>
                 &lt;
               </a>
@@ -307,8 +344,8 @@ function Home(props) {
                 </a>
               </li>
             ))}
-            <li>
-              <a href="#!" onClick={nextPage}>
+            <li className={`${currentPage === npage ? "disable" : ""}`} title="No Next Page">
+              <a href="#!" onClick={nextPage} >
                 &gt;
               </a>
             </li>

--- a/frontend/src/style/Home.css
+++ b/frontend/src/style/Home.css
@@ -82,9 +82,22 @@
   display: inline;
 }
 
+.pagination .disable a{
+  background: rgb(201, 86, 86);
+  color: #ffb347;
+}
+
+.pagination .disable a:hover{
+  background: rgb(201, 86, 86);
+  color: #ffb347;
+}
 .pagination a {
   display: block;
-  padding: 10px 15px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 50px;
+  height: 50px;
   text-decoration: none;
   color: #ffb347; /* Light orange text color */
   background-color: #333; /* Dark background color */


### PR DESCRIPTION
## Related Issue
#503

## Description
Fixes pagination behaviour on category change, now on change category pagination pageNo always point to 1(one) at start irrespective of which pageNo it was in the previous category.
Now pagination behaves very smooth means pagination will display only 5 pages at a time but if totalPage < 5 then is display only that amount of pages.

## Type of PR

- [X] Bug fix


## Screenshots / videos (if applicable)
https://github.com/HimanshuNarware/Devlabs/assets/97510973/bcc786dd-8d8e-4a4e-896d-8a56828a9a6b


## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.

## Additional context:
can we use state manager instead of localstorage for category linking.