### PR TITLE
Fix: scroll To Bottom Disapper for the upper half of the window

### DIFF
--- a/frontend/src/Component/BackToTopButton.js
+++ b/frontend/src/Component/BackToTopButton.js
@@ -1,25 +1,27 @@
 import React, { useState, useEffect } from 'react';
 import '../style/BackToTopButton.css';
-
 import { MdKeyboardDoubleArrowUp } from "react-icons/md";
 
 function BackToTopButton() {
     const [isVisible, setIsVisible] = useState(false);
 
     useEffect(() => {
+        const handleScroll = () => {
+            const documentHeight = document.documentElement.scrollHeight - window.innerHeight;
+            const scrollOffset = documentHeight * 0.5;
+
+            if (window.scrollY > scrollOffset) {
+                setIsVisible(true);
+            } else {
+                setIsVisible(false);
+            }
+        };
+
         window.addEventListener('scroll', handleScroll);
         return () => {
             window.removeEventListener('scroll', handleScroll);
         };
     }, []);
-
-    const handleScroll = () => {
-        if (window.scrollY > 100) {
-            setIsVisible(true);
-        } else {
-            setIsVisible(false);
-        }
-    };
 
     const scrollToTop = () => {
         window.scrollTo({
@@ -28,27 +30,21 @@ function BackToTopButton() {
         });
     };
 
-
     const iconStyle = {
-        width: '2.5rem',  
+        width: '2.5rem',
         height: '2.5rem',
         filter: 'brightness(0) invert(1)',
-        
-
-        };
-    
+    };
 
     return (
         <a href='#hero'>
-
-        <button
-            onClick={scrollToTop}
-            className={`back-to-top-button ${isVisible ? 'visible' : ''}`}
-        >
-        <MdKeyboardDoubleArrowUp style={iconStyle}/>
-
-        <span className='tooltiptext'>Go top page</span>
-        </button>
+            <button
+                onClick={scrollToTop}
+                className={`back-to-top-button ${isVisible ? 'visible' : ''}`}
+            >
+                <MdKeyboardDoubleArrowUp style={iconStyle} />
+                <span className='tooltiptext'>Go top page</span>
+            </button>
         </a>
     );
 }

--- a/frontend/src/style/BackToTopButton.css
+++ b/frontend/src/style/BackToTopButton.css
@@ -3,6 +3,7 @@
     bottom: 80px;
     right: 20px;
     z-index: 10;
+    display: none;
     background-color: #00c68a;
     color: white;
     border: 2px solid #93FFD8;
@@ -21,9 +22,14 @@
 }
 .back-to-top-button.visible {
     display: block;
+    opacity: 1;
+    transform: translateY(0);
 }
 
-
+.back-to-top-button:not(.visible) {
+    opacity: 0;
+    transform: translateY(20px);
+}
 .back-to-top-button:hover{
     background-color: rgba(17, 99, 76, 0.856);
     transform: scale(1.1);


### PR DESCRIPTION
## Related Issue
Fixes #1876 

## Description
I have a hiding property for the scroll to the top button. There is no sense in displaying a button for the upper half of the page.

## Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)

https://github.com/user-attachments/assets/dd5eba9a-aed4-4cdb-bd3c-81ce8a65a608



## Checklist:
- [X] I have performed a self-review of my code
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

