### PR TITLE
Removed the blank space of right side of the home page in mobile-view.

### DIFF
--- a/frontend/src/Component/Footer.js
+++ b/frontend/src/Component/Footer.js
@@ -29,7 +29,7 @@ import { Link } from "react-router-dom";
 
 function Footer() {
   return (
-    <footer>
+    <footer className="overflow-x-hidden">
       <div className="Footer">
         <div className="container">
           <div className="row">

--- a/frontend/src/Component/Navbar/Navbar.js
+++ b/frontend/src/Component/Navbar/Navbar.js
@@ -9,7 +9,7 @@ function Navbar(props) {
   
   return (
     <header>
-      <div className="navbar">
+      <div className="navbar w-100">
         <NavbarLeft showSideNav={showSideNav} setShowSideNav={setShowSideNav} />
         <NavbarCenter showSideNav={showSideNav} />
         


### PR DESCRIPTION
## Related Issue
Fixes: #1850 

## Description
- Removed the blank space of right side of the home page in mobile view.
- Now the home page is looking responsive on mobile view.

## Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)


https://github.com/user-attachments/assets/1befa8b8-6ddc-4db2-a6ac-b2d2d08cecc2




## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
_Please review and merge my pull-request under GSSoC'24_
