### PR TITLE
Added iterm2

### DIFF
--- a/frontend/src/DB/product.json
+++ b/frontend/src/DB/product.json
@@ -1,5 +1,12 @@
 [
   {
+    "productName": "iTerm2",
+    "category": "Tool",
+    "image": "https://iterm2.com/img/logo2x.jpg",
+    "link": "https://iterm2.com/",
+    "description": "iTerm2 is a replacement for Terminal and the successor to iTerm. It works on Macs with macOS 10.14 or newer. iTerm2 brings the terminal into the modern age with features you never knew you always wanted."
+},
+  {
     "productName": "Sentry",
     "category": "Tool",
     "image": "https://www.sentry.io/_assets/branding/png/sentry-horizontal-black.png",


### PR DESCRIPTION
## Related Issue
#2728 

## Description

iTerm2 is a replacement for Terminal and the successor to iTerm. It works on Macs with macOS 10.14 or newer. iTerm2 brings the terminal into the modern age with features you never knew you always wanted

## Type of PR

- [ ] Bug fix
- [x] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
[Attach any relevant screenshots or videos demonstrating the changes]

## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
[Include any additional information or context that might be helpful for reviewers.]
