### PR TITLE
Fix: Fixed the duplicate tools workflows

### DIFF
--- a/.github/workflows/check_duplicate_tools.yml
+++ b/.github/workflows/check_duplicate_tools.yml
@@ -13,14 +13,14 @@ jobs:
 
     - name: Check for duplicate entries in product.json
       run: |
-        # Check for duplicate entries in product.json
-        jq -r '.[].productName' product.json | sort | uniq -d > duplicates.txt
+        # Check for duplicate entries based on the 'link' field in product.json
+        jq -r '.[].link' product.json | sort | uniq -d > duplicates.txt
         if [ -s duplicates.txt ]; then
-          echo "Duplicate entries found in product.json:"
+          echo "Duplicate entries found in product.json based on 'link':"
           cat duplicates.txt
           exit 1
         else
-          echo "No duplicate entries found."
+          echo "No duplicate entries found based on 'link'."
         fi
 
   close-issues:


### PR DESCRIPTION
## Related Issue
Fixes #2875 

## Description
The updated GitHub Actions workflow now ensures that no duplicate tools are added to the `product.json` database by checking for duplicate entries based on the `link` field instead of `productName`.

## Type of PR

- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
[Attach any relevant screenshots or videos demonstrating the changes]

## Checklist:
- [X] I have performed a self-review of my code
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X]  I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->
